### PR TITLE
Signup user interests implementation + All current tests now passing

### DIFF
--- a/src/main/Java/interface_adapter/signup/event_poster_signup/EventPosterSignupController.java
+++ b/src/main/Java/interface_adapter/signup/event_poster_signup/EventPosterSignupController.java
@@ -1,7 +1,10 @@
 package interface_adapter.signup.event_poster_signup;
 
+import entity.Event;
 import use_case.signup.event_poster_signup.EventPosterSignupInputBoundary;
 import use_case.signup.event_poster_signup.EventPosterSignupInputData;
+
+import java.util.Map;
 
 public class EventPosterSignupController {
 
@@ -23,9 +26,10 @@ public class EventPosterSignupController {
                         String password,
                         String confirmPassword,
                         String organizationName,
-                        String sopLink) {
+                        String sopLink,
+                        Map<String, Event> events) {
         final EventPosterSignupInputData eventPosterSignupInputData = new EventPosterSignupInputData(
-                username, password, confirmPassword, organizationName, sopLink);
+                username, password, confirmPassword, organizationName, sopLink, events);
 
         eventPosterSignupUseCaseInteractor.execute(eventPosterSignupInputData);
 

--- a/src/main/Java/interface_adapter/signup/event_poster_signup/EventPosterSignupState.java
+++ b/src/main/Java/interface_adapter/signup/event_poster_signup/EventPosterSignupState.java
@@ -1,5 +1,10 @@
 package interface_adapter.signup.event_poster_signup;
 
+import entity.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The state for the Signup View Model.
  */
@@ -12,6 +17,7 @@ public class EventPosterSignupState {
     private String repeatPasswordError;
     private String organizationName;
     private String sopLink;
+    private Map<String, Event> events = new HashMap<String, Event>();
 
     public String getUsername() {
         return username;
@@ -40,6 +46,8 @@ public class EventPosterSignupState {
     public String getOrganizationName() { return organizationName; }
 
     public String getSopLink() { return sopLink; }
+
+    public Map<String, Event> getEvents() { return events; }
 
     public void setUsername(String username) {
         this.username = username;
@@ -77,6 +85,7 @@ public class EventPosterSignupState {
                 + ", repeatPassword='" + repeatPassword + '\''
                 + ", organizationName='" + organizationName + '\''
                 + ", sopLink='" + sopLink + '\''
+                + ", events='" + events + '\''
                 + '}';
     }
 }

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
@@ -24,12 +24,14 @@ public class UserSignupController {
     public void execute(String username,
                         String password,
                         String confirmPassword,
-                        String gender,
+                        String firstName,
+                        String lastName,
                         Integer age,
+                        String gender,
                         List<String> interests) {
 
         final UserSignupInputData userSignupInputData = new UserSignupInputData(
-                username, password, confirmPassword, gender, age, interests);
+                username, password, confirmPassword, firstName, lastName, age, gender, interests);
 
         userSignupUseCaseInteractor.execute(userSignupInputData);
 

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
@@ -3,6 +3,8 @@ package interface_adapter.signup.general_user_signup;
 import use_case.signup.general_user_signup.UserSignupInputBoundary;
 import use_case.signup.general_user_signup.UserSignupInputData;
 
+import java.util.List;
+
 public class UserSignupController {
 
     private final UserSignupInputBoundary userSignupUseCaseInteractor;
@@ -23,7 +25,8 @@ public class UserSignupController {
                         String password,
                         String confirmPassword,
                         String gender,
-                        Integer age) {
+                        Integer age,
+                        List<String> interests) {
 
         final UserSignupInputData userSignupInputData = new UserSignupInputData(
                 username, password, confirmPassword, gender, age);

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupController.java
@@ -29,7 +29,7 @@ public class UserSignupController {
                         List<String> interests) {
 
         final UserSignupInputData userSignupInputData = new UserSignupInputData(
-                username, password, confirmPassword, gender, age);
+                username, password, confirmPassword, gender, age, interests);
 
         userSignupUseCaseInteractor.execute(userSignupInputData);
 

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupState.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupState.java
@@ -15,12 +15,15 @@ public class UserSignupState {
     private String gender = "";
     private Integer age;
     private String ageError;
-    private List<String> interest;
+    private List<String> interests;
+    private String firstName = "";
+    private String lastName = "";
+    private String firstNameError;
+    private String lastNameError;
 
     public String getUsername() {
         return username;
     }
-
     public String getUsernameError() {
         return usernameError;
     }
@@ -28,7 +31,6 @@ public class UserSignupState {
     public String getPassword() {
         return password;
     }
-
     public String getPasswordError() {
         return passwordError;
     }
@@ -36,7 +38,6 @@ public class UserSignupState {
     public String getRepeatPassword() {
         return repeatPassword;
     }
-
     public String getRepeatPasswordError() {
         return repeatPasswordError;
     }
@@ -44,10 +45,15 @@ public class UserSignupState {
     public String getGender() {return gender;}
 
     public Integer getAge() { return age; }
-
     public String getAgeError() { return ageError; }
 
-    public List<String>  getInterests() { return interest; }
+    public String getFirstName() { return firstName; }
+    public String getFirstNameError() { return firstNameError; }
+
+    public String getLastName() { return lastName; }
+    public String getLastNameError() { return lastNameError; }
+
+    public List<String>  getInterests() { return interests; }
 
     public void setUsername(String username) {
         this.username = username;
@@ -79,7 +85,10 @@ public class UserSignupState {
 
     public void setAgeError(String ageError) { this.ageError = ageError; }
 
-    public void setInterests(List<String> interest) { this.interest = interest; }
+    public void setInterests(List<String> interest) { this.interests = interest; }
+
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
 
     @Override
     public String toString() {
@@ -87,9 +96,11 @@ public class UserSignupState {
                 + "username='" + username + '\''
                 + ", password='" + password + '\''
                 + ", repeatPassword='" + repeatPassword + '\''
+                + ", firstName='" + firstName + '\''
+                + ", lastName='" + lastName + '\''
                 + ", gender='" + gender + '\''
                 + ", age='" + age + '\''
-                + ", interest='" + interest + '\''
+                + ", interests='" + interests + '\''
                 + '}';
     }
 }

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupState.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupState.java
@@ -1,5 +1,7 @@
 package interface_adapter.signup.general_user_signup;
 
+import java.util.List;
+
 /**
  * The state for the Signup View Model.
  */
@@ -10,9 +12,10 @@ public class UserSignupState {
     private String passwordError;
     private String repeatPassword = "";
     private String repeatPasswordError;
-    private String gender;
+    private String gender = "";
     private Integer age;
     private String ageError;
+    private List<String> interest;
 
     public String getUsername() {
         return username;
@@ -44,6 +47,8 @@ public class UserSignupState {
 
     public String getAgeError() { return ageError; }
 
+    public List<String>  getInterests() { return interest; }
+
     public void setUsername(String username) {
         this.username = username;
     }
@@ -74,6 +79,8 @@ public class UserSignupState {
 
     public void setAgeError(String ageError) { this.ageError = ageError; }
 
+    public void setInterests(List<String> interest) { this.interest = interest; }
+
     @Override
     public String toString() {
         return "UserSignupState{"
@@ -82,6 +89,7 @@ public class UserSignupState {
                 + ", repeatPassword='" + repeatPassword + '\''
                 + ", gender='" + gender + '\''
                 + ", age='" + age + '\''
+                + ", interest='" + interest + '\''
                 + '}';
     }
 }

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
@@ -10,6 +10,8 @@ public class UserSignupViewModel extends ViewModel<UserSignupState> {
     public static final String AGE_LABEL = "Age";
     public static final String TITLE_LABEL = "General User Signup";
     public static final List<String> INTEREST_SELECTION_OPTIONS = List.of("sports", "music", "visual art");
+    public static final String FIRST_NAME_LABEL = "First Name";
+    public static final String LAST_NAME_LABEL = "Last Name";
 
 
     public UserSignupViewModel() {

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
@@ -2,11 +2,14 @@ package interface_adapter.signup.general_user_signup;
 
 import interface_adapter.ViewModel;
 
+import java.util.List;
+
 public class UserSignupViewModel extends ViewModel<UserSignupState> {
 
     public static final String GENDER_LABEL = "Gender";
     public static final String AGE_LABEL = "Age";
     public static final String TITLE_LABEL = "General User Signup";
+    public static final List<String> INTEREST_SELECTION_OPTIONS = List.of("sports", "music", "visual art");
 
 
     public UserSignupViewModel() {

--- a/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
+++ b/src/main/Java/interface_adapter/signup/general_user_signup/UserSignupViewModel.java
@@ -6,13 +6,14 @@ import java.util.List;
 
 public class UserSignupViewModel extends ViewModel<UserSignupState> {
 
-    public static final String GENDER_LABEL = "Gender";
     public static final String AGE_LABEL = "Age";
     public static final String TITLE_LABEL = "General User Signup";
+    public static final String INTEREST_SELECTION_LABEL = "Select your Interests";
     public static final List<String> INTEREST_SELECTION_OPTIONS = List.of("sports", "music", "visual art");
     public static final String FIRST_NAME_LABEL = "First Name";
     public static final String LAST_NAME_LABEL = "Last Name";
-
+    public static final String GENDER_LABEL = "Gender";
+    public static final List<String> GENDER_SELECTION_OPTIONS = List.of("male", "female", "other");
 
     public UserSignupViewModel() {
         super("User Signup Screen");

--- a/src/main/Java/use_case/signup/event_poster_signup/EventPosterSignupInputData.java
+++ b/src/main/Java/use_case/signup/event_poster_signup/EventPosterSignupInputData.java
@@ -1,5 +1,10 @@
 package use_case.signup.event_poster_signup;
 
+import entity.Event;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class EventPosterSignupInputData {
 
     private final String username;
@@ -7,17 +12,20 @@ public class EventPosterSignupInputData {
     private final String repeatPassword;
     private final String organizationName;
     private final String sopLink;
+    private final Map<String, Event> events;
 
     public EventPosterSignupInputData(String username,
                                       String password,
                                       String repeatPassword,
                                       String organizationName,
-                                      String sopLink) {
+                                      String sopLink,
+                                      Map<String, Event> events) {
         this.username = username;
         this.password = password;
         this.repeatPassword = repeatPassword;
         this.organizationName = organizationName;
         this.sopLink = sopLink;
+        this.events = events;
     }
 
     String getUsername() { return username; }
@@ -25,5 +33,6 @@ public class EventPosterSignupInputData {
     String getRepeatPassword() { return repeatPassword; }
     String getOrganizationName() { return organizationName; }
     String getSopLink() { return sopLink; }
+    Map<String, Event> getEvents() { return events; }
 
 }

--- a/src/main/Java/use_case/signup/event_poster_signup/EventPosterSignupInteractor.java
+++ b/src/main/Java/use_case/signup/event_poster_signup/EventPosterSignupInteractor.java
@@ -30,9 +30,9 @@ public class EventPosterSignupInteractor implements EventPosterSignupInputBounda
             final Account eventPoster = accountCreator.createAccount(
                     eventPosterSignupInputData.getUsername(),
                     eventPosterSignupInputData.getPassword(),
-                    eventPosterSignupInputData.getRepeatPassword(),
                     eventPosterSignupInputData.getOrganizationName(),
-                    eventPosterSignupInputData.getSopLink());
+                    eventPosterSignupInputData.getSopLink(),
+                    eventPosterSignupInputData.getEvents());
 
             userDataAccessObject.save(eventPoster);
             final EventPosterSignupOutputData signupOutputData = new EventPosterSignupOutputData(eventPoster.getUsername(), false);

--- a/src/main/Java/use_case/signup/general_user_signup/UserSignupInputData.java
+++ b/src/main/Java/use_case/signup/general_user_signup/UserSignupInputData.java
@@ -1,5 +1,7 @@
 package use_case.signup.general_user_signup;
 
+import java.util.List;
+
 public class UserSignupInputData {
 
     private final String username;
@@ -7,17 +9,20 @@ public class UserSignupInputData {
     private final String repeatPassword;
     private final String gender;
     private final Integer age;
+    private final List<String> interests;
 
     public UserSignupInputData(String username,
                                String password,
                                String repeatPassword,
                                String gender,
-                               Integer age) {
+                               Integer age,
+                               List<String> interests) {
         this.username = username;
         this.password = password;
         this.repeatPassword = repeatPassword;
         this.age = age;
         this.gender = gender;
+        this.interests = interests;
     }
 
     String getUsername() { return username; }
@@ -25,5 +30,6 @@ public class UserSignupInputData {
     String getRepeatPassword() { return repeatPassword; }
     String getGender() { return gender; }
     Integer getAge() { return age; }
+    List<String> getInterests() { return interests; }
 
 }

--- a/src/main/Java/use_case/signup/general_user_signup/UserSignupInputData.java
+++ b/src/main/Java/use_case/signup/general_user_signup/UserSignupInputData.java
@@ -7,6 +7,8 @@ public class UserSignupInputData {
     private final String username;
     private final String password;
     private final String repeatPassword;
+    private final String firstName;
+    private final String lastName;
     private final String gender;
     private final Integer age;
     private final List<String> interests;
@@ -14,11 +16,15 @@ public class UserSignupInputData {
     public UserSignupInputData(String username,
                                String password,
                                String repeatPassword,
-                               String gender,
+                               String firstName,
+                               String lastName,
                                Integer age,
+                               String gender,
                                List<String> interests) {
         this.username = username;
         this.password = password;
+        this.firstName = firstName;
+        this.lastName = lastName;
         this.repeatPassword = repeatPassword;
         this.age = age;
         this.gender = gender;
@@ -31,5 +37,7 @@ public class UserSignupInputData {
     String getGender() { return gender; }
     Integer getAge() { return age; }
     List<String> getInterests() { return interests; }
+    String getFirstName() { return firstName; }
+    String getLastName() { return lastName; }
 
 }

--- a/src/main/Java/use_case/signup/general_user_signup/UserSignupInteractor.java
+++ b/src/main/Java/use_case/signup/general_user_signup/UserSignupInteractor.java
@@ -36,7 +36,8 @@ public class UserSignupInteractor implements UserSignupInputBoundary {
                     userSignupInputData.getPassword(),
                     userSignupInputData.getRepeatPassword(),
                     userSignupInputData.getAge(),
-                    userSignupInputData.getGender());
+                    userSignupInputData.getGender(),
+                    userSignupInputData.getInterests());
 
             userDataAccessObject.save(user);
             final UserSignupOutputData signupOutputData= new UserSignupOutputData(user.getUsername(), false);

--- a/src/main/Java/use_case/signup/general_user_signup/UserSignupInteractor.java
+++ b/src/main/Java/use_case/signup/general_user_signup/UserSignupInteractor.java
@@ -34,7 +34,8 @@ public class UserSignupInteractor implements UserSignupInputBoundary {
             final Account user = accountCreator.createAccount(
                     userSignupInputData.getUsername(),
                     userSignupInputData.getPassword(),
-                    userSignupInputData.getRepeatPassword(),
+                    userSignupInputData.getFirstName(),
+                    userSignupInputData.getLastName(),
                     userSignupInputData.getAge(),
                     userSignupInputData.getGender(),
                     userSignupInputData.getInterests());

--- a/src/main/Java/views/signup/EventPosterSignupView.java
+++ b/src/main/Java/views/signup/EventPosterSignupView.java
@@ -95,7 +95,8 @@ public class EventPosterSignupView extends BaseSignupView<EventPosterSignupViewM
                                 currentState.getPassword(),
                                 currentState.getRepeatPassword(),
                                 currentState.getOrganizationName(),
-                                currentState.getSopLink()
+                                currentState.getSopLink(),
+                                currentState.getEvents()
                         );
                     }
                 }

--- a/src/main/Java/views/signup/GeneralUserSignupView.java
+++ b/src/main/Java/views/signup/GeneralUserSignupView.java
@@ -61,7 +61,7 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
             interestSelectionPanel.add(checkBox);
         });
 
-        interestScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        interestScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
         interestScrollPane.setPreferredSize(new Dimension(200, 100)); // Adjust size as needed
 
         addInterestListeners();
@@ -86,6 +86,7 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         currentState.setInterests(selectedInterests); // Assuming there's a setSelectedInterests method
         viewModel.setState(currentState);
     }
+
 
     private void addGenderListener() {
         genderInputField.getDocument().addDocumentListener(new DocumentListener() {
@@ -239,8 +240,7 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                         currentState.getRepeatPassword(),
                         currentState.getGender(),
                         currentState.getAge(),
-                        currentState.getInterests() // Pass selected interests
-                );
+                        currentState.getInterests());
             }
         });
     }

--- a/src/main/Java/views/signup/GeneralUserSignupView.java
+++ b/src/main/Java/views/signup/GeneralUserSignupView.java
@@ -12,6 +12,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.List;
 
 public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> implements ActionListener, PropertyChangeListener {
 
@@ -19,6 +21,9 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
     private final JTextField genderInputField = new JTextField(15);
     private final JTextField ageInputField = new JTextField(15);
+    private final JPanel interestSelectionPanel = new JPanel();
+    private final JScrollPane interestScrollPane = new JScrollPane(interestSelectionPanel);
+    private final List<JCheckBox> interestCheckBoxes = new ArrayList<>();
 
     public GeneralUserSignupView(UserSignupViewModel userSignupViewModel) {
         super(userSignupViewModel);
@@ -29,15 +34,57 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         final LabelTextPanel genderInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.GENDER_LABEL), genderInputField);
         final LabelTextPanel ageInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.AGE_LABEL), ageInputField);
 
+        setupInterestPicker();
+
         JPanel additionalFieldsPanel = new JPanel();
         additionalFieldsPanel.setLayout(new BoxLayout(additionalFieldsPanel, BoxLayout.Y_AXIS));
         additionalFieldsPanel.add(genderInfo);
         additionalFieldsPanel.add(ageInfo);
+        additionalFieldsPanel.add(interestScrollPane);
 
         additionalFieldsContainer.add(additionalFieldsPanel);
 
         addGenderListener();
         addAgeListener();
+    }
+
+    private void setupInterestPicker() {
+        interestSelectionPanel.setLayout(new BoxLayout(interestSelectionPanel, BoxLayout.Y_AXIS));
+
+        JLabel interestLabel = new JLabel("Select Your Interests:");
+        interestLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        interestSelectionPanel.add(interestLabel);
+
+        UserSignupViewModel.INTEREST_SELECTION_OPTIONS.forEach(interest -> {
+            JCheckBox checkBox = new JCheckBox(interest);
+            interestCheckBoxes.add(checkBox);
+            interestSelectionPanel.add(checkBox);
+        });
+
+        interestScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        interestScrollPane.setPreferredSize(new Dimension(200, 100)); // Adjust size as needed
+
+        addInterestListeners();
+    }
+
+    private void addInterestListeners() {
+        for (JCheckBox checkBox : interestCheckBoxes) {
+            checkBox.addActionListener(e -> updateSelectedInterests());
+        }
+    }
+
+    private void updateSelectedInterests() {
+        List<String> selectedInterests = new ArrayList<>();
+        for (JCheckBox checkBox : interestCheckBoxes) {
+            if (checkBox.isSelected()) {
+                selectedInterests.add(checkBox.getText());
+            }
+        }
+
+        // Update the view model state with the selected interests
+        final UserSignupState currentState = viewModel.getState();
+        currentState.setInterests(selectedInterests); // Assuming there's a setSelectedInterests method
+        viewModel.setState(currentState);
     }
 
     private void addGenderListener() {
@@ -47,14 +94,17 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                 currentState.setGender(genderInputField.getText());
                 viewModel.setState(currentState);
             }
+
             @Override
             public void insertUpdate(DocumentEvent e) {
                 updateState();
             }
+
             @Override
             public void removeUpdate(DocumentEvent e) {
                 updateState();
             }
+
             @Override
             public void changedUpdate(DocumentEvent e) {
                 updateState();
@@ -64,18 +114,6 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
     private void addAgeListener() {
         ageInputField.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                updateState();
-            }
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                updateState();
-            }
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                updateState();
-            }
             private void updateState() {
                 UserSignupState currentState = viewModel.getState();
                 try {
@@ -85,6 +123,21 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                     currentState.setAgeError("Please enter a valid age.");
                 }
                 viewModel.setState(currentState);
+            }
+
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateState();
             }
         });
     }
@@ -97,14 +150,17 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                 currentState.setUsername(usernameInputField.getText());
                 viewModel.setState(currentState);
             }
+
             @Override
             public void insertUpdate(DocumentEvent e) {
                 documentListenerHelper();
             }
+
             @Override
             public void removeUpdate(DocumentEvent e) {
                 documentListenerHelper();
             }
+
             @Override
             public void changedUpdate(DocumentEvent e) {
                 documentListenerHelper();
@@ -121,10 +177,12 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                 currentState.setPassword(new String(passwordInputField.getPassword()));
                 viewModel.setState(currentState);
             }
+
             @Override
             public void insertUpdate(DocumentEvent e) {
                 documentListenerHelper();
             }
+
             @Override
             public void removeUpdate(DocumentEvent e) {
                 documentListenerHelper();
@@ -145,14 +203,17 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                 currentState.setRepeatPassword(new String(confirmPasswordInputField.getPassword()));
                 viewModel.setState(currentState);
             }
+
             @Override
             public void insertUpdate(DocumentEvent e) {
                 documentListenerHelper();
             }
+
             @Override
             public void removeUpdate(DocumentEvent e) {
                 documentListenerHelper();
             }
+
             @Override
             public void changedUpdate(DocumentEvent e) {
                 documentListenerHelper();
@@ -170,19 +231,18 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
     @Override
     protected void addSignupButtonListener() {
         signUp.addActionListener(evt -> {
-                    if (evt.getSource().equals(signUp)) {
-                        final UserSignupState currentState = viewModel.getState();
-
-                        userSignupController.execute(
-                                currentState.getUsername(),
-                                currentState.getPassword(),
-                                currentState.getRepeatPassword(),
-                                currentState.getGender(),
-                                currentState.getAge()
-                        );
-                    }
-                }
-        );
+            if (evt.getSource().equals(signUp)) {
+                final UserSignupState currentState = viewModel.getState();
+                userSignupController.execute(
+                        currentState.getUsername(),
+                        currentState.getPassword(),
+                        currentState.getRepeatPassword(),
+                        currentState.getGender(),
+                        currentState.getAge(),
+                        currentState.getInterests() // Pass selected interests
+                );
+            }
+        });
     }
 
     public void setAccountTypeController(UserSignupController userSignupController) {

--- a/src/main/Java/views/signup/GeneralUserSignupView.java
+++ b/src/main/Java/views/signup/GeneralUserSignupView.java
@@ -21,11 +21,12 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
     private final JTextField firstNameInputField = new JTextField(15);
     private final JTextField lastNameInputField = new JTextField(15);
-    private final JTextField genderInputField = new JTextField(15);
     private final JTextField ageInputField = new JTextField(15);
     private final JPanel interestSelectionPanel = new JPanel();
     private final JScrollPane interestScrollPane = new JScrollPane(interestSelectionPanel);
     private final List<JCheckBox> interestCheckBoxes = new ArrayList<>();
+    private final JComboBox<String> genderComboBox = new JComboBox<>();
+    private final JPanel genderSelectionPanel = new JPanel();
 
     public GeneralUserSignupView(UserSignupViewModel userSignupViewModel) {
         super(userSignupViewModel);
@@ -35,19 +36,19 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
         final LabelTextPanel firstNameInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.FIRST_NAME_LABEL), firstNameInputField);
         final LabelTextPanel lastNameInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.LAST_NAME_LABEL), lastNameInputField);
-        final LabelTextPanel genderInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.GENDER_LABEL), genderInputField);
         final LabelTextPanel ageInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.AGE_LABEL), ageInputField);
 
         setupInterestPicker();
+        setupGenderComboBox();
 
         JPanel additionalFieldsPanel = new JPanel();
         additionalFieldsPanel.setLayout(new BoxLayout(additionalFieldsPanel, BoxLayout.Y_AXIS));
 
         additionalFieldsPanel.add(firstNameInfo);
         additionalFieldsPanel.add(lastNameInfo);
-        additionalFieldsPanel.add(genderInfo);
         additionalFieldsPanel.add(ageInfo);
-        additionalFieldsPanel.add(interestScrollPane);
+        additionalFieldsPanel.add(genderSelectionPanel);
+        additionalFieldsPanel.add(interestSelectionPanel);
 
         additionalFieldsContainer.add(additionalFieldsPanel);
 
@@ -57,13 +58,25 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         addAgeListener();
     }
 
+    private void setupGenderComboBox() {
+        genderSelectionPanel.add(new JLabel(UserSignupViewModel.GENDER_LABEL));
+        genderSelectionPanel.add(genderComboBox);
+
+        for (String genderOption : UserSignupViewModel.GENDER_SELECTION_OPTIONS) {
+            genderComboBox.addItem(genderOption);
+        }
+        genderComboBox.setPreferredSize(new Dimension(200, 25));
+        genderComboBox.addActionListener(e -> {
+            UserSignupState currentState = viewModel.getState();
+            currentState.setGender((String) genderComboBox.getSelectedItem());
+            viewModel.setState(currentState);
+        });
+    }
+
     private void setupInterestPicker() {
         interestSelectionPanel.setLayout(new BoxLayout(interestSelectionPanel, BoxLayout.Y_AXIS));
 
-        JLabel interestLabel = new JLabel("Select Your Interests:");
-        interestLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
-        interestSelectionPanel.add(interestLabel);
-
+        interestSelectionPanel.add(new JLabel(UserSignupViewModel.INTEREST_SELECTION_LABEL));
         UserSignupViewModel.INTEREST_SELECTION_OPTIONS.forEach(interest -> {
             JCheckBox checkBox = new JCheckBox(interest);
             interestCheckBoxes.add(checkBox);
@@ -71,8 +84,7 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         });
 
         interestScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
-        interestScrollPane.setPreferredSize(new Dimension(200, 100)); // Adjust size as needed
-
+        interestScrollPane.setPreferredSize(new Dimension(200, 100));
         addInterestListeners();
     }
 
@@ -90,9 +102,8 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
             }
         }
 
-        // Update the view model state with the selected interests
         final UserSignupState currentState = viewModel.getState();
-        currentState.setInterests(selectedInterests); // Assuming there's a setSelectedInterests method
+        currentState.setInterests(selectedInterests);
         viewModel.setState(currentState);
     }
 
@@ -147,27 +158,11 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
     }
 
     private void addGenderListener() {
-        genderInputField.getDocument().addDocumentListener(new DocumentListener() {
-            private void updateState() {
-                UserSignupState currentState = viewModel.getState();
-                currentState.setGender(genderInputField.getText());
-                viewModel.setState(currentState);
-            }
-
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                updateState();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                updateState();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                updateState();
-            }
+        genderComboBox.addActionListener(e -> {
+            String selectedGender = (String) genderComboBox.getSelectedItem();
+            UserSignupState currentState = viewModel.getState();
+            currentState.setGender(selectedGender);
+            viewModel.setState(currentState);
         });
     }
 

--- a/src/main/Java/views/signup/GeneralUserSignupView.java
+++ b/src/main/Java/views/signup/GeneralUserSignupView.java
@@ -19,6 +19,8 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
     private UserSignupController userSignupController;
 
+    private final JTextField firstNameInputField = new JTextField(15);
+    private final JTextField lastNameInputField = new JTextField(15);
     private final JTextField genderInputField = new JTextField(15);
     private final JTextField ageInputField = new JTextField(15);
     private final JPanel interestSelectionPanel = new JPanel();
@@ -31,6 +33,8 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         final JLabel title = new JLabel(UserSignupViewModel.TITLE_LABEL);
         title.setAlignmentX(Component.CENTER_ALIGNMENT);
 
+        final LabelTextPanel firstNameInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.FIRST_NAME_LABEL), firstNameInputField);
+        final LabelTextPanel lastNameInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.LAST_NAME_LABEL), lastNameInputField);
         final LabelTextPanel genderInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.GENDER_LABEL), genderInputField);
         final LabelTextPanel ageInfo = new LabelTextPanel(new JLabel(UserSignupViewModel.AGE_LABEL), ageInputField);
 
@@ -38,12 +42,17 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
 
         JPanel additionalFieldsPanel = new JPanel();
         additionalFieldsPanel.setLayout(new BoxLayout(additionalFieldsPanel, BoxLayout.Y_AXIS));
+
+        additionalFieldsPanel.add(firstNameInfo);
+        additionalFieldsPanel.add(lastNameInfo);
         additionalFieldsPanel.add(genderInfo);
         additionalFieldsPanel.add(ageInfo);
         additionalFieldsPanel.add(interestScrollPane);
 
         additionalFieldsContainer.add(additionalFieldsPanel);
 
+        addFirstNameListener();
+        addLastNameListener();
         addGenderListener();
         addAgeListener();
     }
@@ -87,6 +96,55 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
         viewModel.setState(currentState);
     }
 
+    private void addFirstNameListener() {
+        firstNameInputField.getDocument().addDocumentListener(new DocumentListener() {
+            private void updateState() {
+                UserSignupState currentState = viewModel.getState();
+                currentState.setFirstName(firstNameInputField.getText());
+                viewModel.setState(currentState);
+            }
+
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateState();
+            }
+        });
+    }
+
+    private void addLastNameListener() {
+        lastNameInputField.getDocument().addDocumentListener(new DocumentListener() {
+            private void updateState() {
+                UserSignupState currentState = viewModel.getState();
+                currentState.setLastName(lastNameInputField.getText());
+                viewModel.setState(currentState);
+            }
+
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateState();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateState();
+            }
+        });
+    }
 
     private void addGenderListener() {
         genderInputField.getDocument().addDocumentListener(new DocumentListener() {
@@ -238,8 +296,10 @@ public class GeneralUserSignupView extends BaseSignupView<UserSignupViewModel> i
                         currentState.getUsername(),
                         currentState.getPassword(),
                         currentState.getRepeatPassword(),
-                        currentState.getGender(),
+                        currentState.getFirstName(),
+                        currentState.getLastName(),
                         currentState.getAge(),
+                        currentState.getGender(),
                         currentState.getInterests());
             }
         });

--- a/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
@@ -8,7 +8,9 @@ import entity.Account;
 import org.junit.jupiter.api.Test;
 import use_case.signup.UserSignupDataAccessInterface;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -17,7 +19,10 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void successTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink");
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+            put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
+        }} );
+
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         EventPosterSignupOutputBoundary successPresenter = new EventPosterSignupOutputBoundary() {
 
@@ -48,8 +53,10 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void failurePasswordMismatchTest() {
-        Map<String, Event > events = new HashMap<>();
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", events);
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "wrong", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+            put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
+        }} );
+
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         EventPosterSignupOutputBoundary failurePresenter = new EventPosterSignupOutputBoundary() {
 
@@ -60,7 +67,7 @@ class EventPosterSignupInteractorTest {
 
             @Override
             public void prepareFailView(String errorMessage) {
-                assertEquals("Passwords don't match.", errorMessage);
+                assertEquals("Passwords do not match.", errorMessage);
             }
 
             @Override
@@ -79,11 +86,17 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void failureUserExistsTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink");
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+            put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
+        }} );
+
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         AccountCreationStrategy accountCreator = new EventPosterCreationStrategy();
-        Account user = accountCreator.createAccount("username", "password", "password", "Organization Name", "sopLink");
+        Account user = accountCreator.createAccount("username", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+            put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
+        }} );
+
         userRepository.save(user);
 
         EventPosterSignupOutputBoundary failurePresenter = new EventPosterSignupOutputBoundary() {

--- a/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
@@ -5,6 +5,7 @@ import entity.AccountCreationStrategy;
 import entity.Event;
 import entity.EventPosterCreationStrategy;
 import entity.Account;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import use_case.signup.UserSignupDataAccessInterface;
 
@@ -18,7 +19,7 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void successTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<>() {{
             put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
         }} );
 
@@ -52,52 +53,36 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void failurePasswordMismatchTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "wrong", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "wrong", "Organization Name", "sopLink", new HashMap<>() {{
             put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
         }} );
 
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        EventPosterSignupOutputBoundary failurePresenter = new EventPosterSignupOutputBoundary() {
-
-            @Override
-            public void prepareSuccessView(EventPosterSignupOutputData eventPoster) {
-                fail("User case failure is unexpected.");
-            }
-
-            @Override
-            public void prepareFailView(String errorMessage) {
-                assertEquals("Passwords do not match.", errorMessage);
-            }
-
-            @Override
-            public void switchToLoginView() {
-                //expected
-            }
-
-            @Override
-            public void switchToBaseView() {
-                //expected
-            }
-        };
-        EventPosterSignupInputBoundary interactor = new EventPosterSignupInteractor(userRepository, failurePresenter, new EventPosterCreationStrategy());
+        EventPosterSignupInputBoundary interactor = getEventPosterSignupInputBoundary("Passwords do not match.", userRepository);
         interactor.execute(inputData);
     }
 
     @Test
     void failureUserExistsTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", new HashMap<>() {{
             put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
         }} );
 
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         AccountCreationStrategy accountCreator = new EventPosterCreationStrategy();
-        Account user = accountCreator.createAccount("username", "password", "Organization Name", "sopLink", new HashMap<String, Event>() {{
+        Account user = accountCreator.createAccount("username", "password", "Organization Name", "sopLink", new HashMap<>() {{
             put("Event1", new Event("Name", "Description", "location", LocalDateTime.now(), LocalDateTime.now(), List.of("tag1", "tag2")));
         }} );
 
         userRepository.save(user);
 
+        EventPosterSignupInputBoundary interactor = getEventPosterSignupInputBoundary("User already exists.", userRepository);
+        interactor.execute(inputData);
+    }
+
+    @NotNull
+    private static EventPosterSignupInputBoundary getEventPosterSignupInputBoundary(String expected, UserSignupDataAccessInterface userRepository) {
         EventPosterSignupOutputBoundary failurePresenter = new EventPosterSignupOutputBoundary() {
 
             @Override
@@ -107,7 +92,7 @@ class EventPosterSignupInteractorTest {
 
             @Override
             public void prepareFailView(String errorMessage) {
-                assertEquals("User already exists.", errorMessage);
+                assertEquals(expected, errorMessage);
             }
 
             @Override
@@ -120,7 +105,6 @@ class EventPosterSignupInteractorTest {
                 //expected
             }
         };
-        EventPosterSignupInputBoundary interactor = new EventPosterSignupInteractor(userRepository, failurePresenter, new EventPosterCreationStrategy());
-        interactor.execute(inputData);
+        return new EventPosterSignupInteractor(userRepository, failurePresenter, new EventPosterCreationStrategy());
     }
 }

--- a/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
@@ -2,10 +2,14 @@ package use_case.signup.event_poster_signup;
 
 import data_access.InMemoryUserDataAccessObject;
 import entity.AccountCreationStrategy;
+import entity.Event;
 import entity.EventPosterCreationStrategy;
 import entity.Account;
 import org.junit.jupiter.api.Test;
 import use_case.signup.UserSignupDataAccessInterface;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -44,7 +48,8 @@ class EventPosterSignupInteractorTest {
 
     @Test
     void failurePasswordMismatchTest() {
-        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink");
+        Map<String, Event > events = new HashMap<>();
+        EventPosterSignupInputData inputData = new EventPosterSignupInputData("username", "password", "password", "Organization Name", "sopLink", events);
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         EventPosterSignupOutputBoundary failurePresenter = new EventPosterSignupOutputBoundary() {
 

--- a/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/event_poster_signup/EventPosterSignupInteractorTest.java
@@ -11,7 +11,6 @@ import use_case.signup.UserSignupDataAccessInterface;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
@@ -15,7 +15,7 @@ class UserSignupInteractorTest {
 
     @Test
     void successTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "firstName", "lastName", 18, "gender", List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         UserSignupOutputBoundary successPresenter = new UserSignupOutputBoundary() {
 
@@ -45,7 +45,7 @@ class UserSignupInteractorTest {
     }
     @Test
     void failurePasswordMismatchTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "wrong", "firstName", "lastName", 18, "gender", List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         UserSignupOutputBoundary failurePresenter = new UserSignupOutputBoundary() {
 
@@ -56,7 +56,7 @@ class UserSignupInteractorTest {
 
             @Override
             public void prepareFailView(String errorMessage) {
-                assertEquals("Passwords don't match.", errorMessage);
+                assertEquals("Passwords do not match", errorMessage);
             }
 
             @Override
@@ -75,11 +75,11 @@ class UserSignupInteractorTest {
 
     @Test
     void failureUserExistsTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "firstName", "lastName", 18, "gender", List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         AccountCreationStrategy accountCreator = new UserCreationStrategy();
-        Account user = accountCreator.createAccount("username", "password", "password", "Organization Name", "sopLink");
+        Account user = accountCreator.createAccount("username", "password", "firstName", "lastName", 18, "gender", List.of("art"));
         userRepository.save(user);
 
         UserSignupOutputBoundary failurePresenter = new UserSignupOutputBoundary() {
@@ -91,7 +91,7 @@ class UserSignupInteractorTest {
 
             @Override
             public void prepareFailView(String errorMessage) {
-                assertEquals("User already exists.", errorMessage);
+                assertEquals("User already exists", errorMessage);
             }
 
             @Override

--- a/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
@@ -7,13 +7,15 @@ import entity.UserCreationStrategy;
 import entity.AccountCreationStrategy;
 import use_case.signup.UserSignupDataAccessInterface;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class UserSignupInteractorTest {
 
     @Test
     void successTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18);
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         UserSignupOutputBoundary successPresenter = new UserSignupOutputBoundary() {
 
@@ -43,7 +45,7 @@ class UserSignupInteractorTest {
     }
     @Test
     void failurePasswordMismatchTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18);
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
         UserSignupOutputBoundary failurePresenter = new UserSignupOutputBoundary() {
 
@@ -73,7 +75,7 @@ class UserSignupInteractorTest {
 
     @Test
     void failureUserExistsTest() {
-        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18);
+        UserSignupInputData inputData = new UserSignupInputData("username", "password", "password", "gender", 18, List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         AccountCreationStrategy accountCreator = new UserCreationStrategy();

--- a/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
+++ b/src/test/java/use_case/signup/general_user_signup/UserSignupInteractorTest.java
@@ -1,6 +1,7 @@
 package use_case.signup.general_user_signup;
 
 import data_access.InMemoryUserDataAccessObject;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import entity.Account;
 import entity.UserCreationStrategy;
@@ -47,29 +48,7 @@ class UserSignupInteractorTest {
     void failurePasswordMismatchTest() {
         UserSignupInputData inputData = new UserSignupInputData("username", "password", "wrong", "firstName", "lastName", 18, "gender", List.of("art"));
         UserSignupDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
-        UserSignupOutputBoundary failurePresenter = new UserSignupOutputBoundary() {
-
-            @Override
-            public void prepareSuccessView(UserSignupOutputData user) {
-                fail("User case failure is unexpected.");
-            }
-
-            @Override
-            public void prepareFailView(String errorMessage) {
-                assertEquals("Passwords do not match", errorMessage);
-            }
-
-            @Override
-            public void switchToLoginView() {
-                //expected
-            }
-
-            @Override
-            public void switchToBaseView() {
-                //expected
-            }
-        };
-        UserSignupInputBoundary interactor = new UserSignupInteractor(userRepository, failurePresenter, new UserCreationStrategy());
+        UserSignupInputBoundary interactor = getUserSignupInputBoundary("Passwords do not match", userRepository);
         interactor.execute(inputData);
     }
 
@@ -82,6 +61,12 @@ class UserSignupInteractorTest {
         Account user = accountCreator.createAccount("username", "password", "firstName", "lastName", 18, "gender", List.of("art"));
         userRepository.save(user);
 
+        UserSignupInputBoundary interactor = getUserSignupInputBoundary("User already exists", userRepository);
+        interactor.execute(inputData);
+    }
+
+    @NotNull
+    private static UserSignupInputBoundary getUserSignupInputBoundary(String userAlreadyExists, UserSignupDataAccessInterface userRepository) {
         UserSignupOutputBoundary failurePresenter = new UserSignupOutputBoundary() {
 
             @Override
@@ -91,7 +76,7 @@ class UserSignupInteractorTest {
 
             @Override
             public void prepareFailView(String errorMessage) {
-                assertEquals("User already exists", errorMessage);
+                assertEquals(userAlreadyExists, errorMessage);
             }
 
             @Override
@@ -104,7 +89,6 @@ class UserSignupInteractorTest {
                 //expected
             }
         };
-        UserSignupInputBoundary interactor = new UserSignupInteractor(userRepository, failurePresenter, new UserCreationStrategy());
-        interactor.execute(inputData);
+        return new UserSignupInteractor(userRepository, failurePresenter, new UserCreationStrategy());
     }
 }


### PR DESCRIPTION
- Users can now pick interests when signing up. I added the missing first name, last name, and interest fields for user signup, and removed the tags field for event signup (since we decided events are event specific, and not event poster specific)
- The gender selection process is now a ComboBox instead of a textfield. This will help keep our user's from picking genders that our program doesnt recognize. 
- Also, any interest or gender list is provided in the signupView, so it is really easy to change without adjusting any code in the view classes. 
- I adjusted the signup process to align with the strategy creation implementations. The signup use case is now working as expected. 

- Additionally, all the current tests for both event poster signup and user signup are passing, meaning our implementation and flow is working as expected.

- My next step with signup is to work on specific error handling (ie. invalid names, no inputs provided, etc) These details will be added in my next pull request
